### PR TITLE
Better define resourcePrefix

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    resourcePrefix 'recycling_center'
+    resourcePrefix 'recycling_center_'
     compileSdkVersion versions.compileSdk
 
     compileOptions {


### PR DESCRIPTION
This property is only necessary in Android Studio but it’s pretty handy during development.
Let’s set it to what we are actually expecting: “recycling_center_” (with the trailing underscore).