### PR TITLE
Less deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ buildscript {
             ],
             'androidx': [
                     'annotation': "androidx.annotation:annotation:${versions.androidx}",
-                    'appcompat': "androidx.appcompat:appcompat:1.1.0",
                     'recyclerview': "androidx.recyclerview:recyclerview:1.0.0",
                     'multidex': 'androidx.multidex:multidex:2.0.1'
             ],

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,9 @@ buildscript {
     }
     ext.versions = [
             'androidx': '1.0.0',
-            'minSdk'    : 14,
             'compileSdk': 29,
+            'minSdk'    : 21,
+            'targetSdk' : 29,
             'errorProne': '2.3.1',
             'kotlin'    : '1.3.71',
             'guava'      : '26.0',
@@ -30,7 +31,6 @@ buildscript {
             ],
             'androidx': [
                     'annotation': "androidx.annotation:annotation:${versions.androidx}",
-                    'collection':"androidx.collection:collection:1.0.0",
                     'v13': "androidx.legacy:legacy-support-v13:1.0.0",
                     'recyclerview': "androidx.recyclerview:recyclerview:1.0.0",
                     'emojiAppCompat': "androidx.emoji:emoji-appcompat:1.0.0",

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ buildscript {
             ],
             'androidx': [
                     'annotation': "androidx.annotation:annotation:${versions.androidx}",
-                    'v13': "androidx.legacy:legacy-support-v13:1.0.0",
                     'recyclerview': "androidx.recyclerview:recyclerview:1.0.0",
                     'emojiAppCompat': "androidx.emoji:emoji-appcompat:1.0.0",
                     'multidex': 'androidx.multidex:multidex:2.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ buildscript {
             ],
             'androidx': [
                     'annotation': "androidx.annotation:annotation:${versions.androidx}",
+                    'appcompat': "androidx.appcompat:appcompat:1.1.0",
                     'recyclerview': "androidx.recyclerview:recyclerview:1.0.0",
-                    'emojiAppCompat': "androidx.emoji:emoji-appcompat:1.0.0",
                     'multidex': 'androidx.multidex:multidex:2.0.1'
             ],
             'mockito': [

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     implementation deps.rx.android
     implementation deps.rx.java
     implementation deps.androidx.annotation
-    implementation deps.androidx.appcompat
     implementation deps.androidx.recyclerview
 
     implementation deps.kotlin.stdlib

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -12,6 +12,8 @@ android {
 
     defaultConfig {
         consumerProguardFiles 'consumer-proguard-rules.txt'
+        minSdkVersion versions.minSdk
+        targetSdkVersion versions.targetSdk
     }
 }
 
@@ -21,7 +23,6 @@ dependencies {
     implementation deps.rx.android
     implementation deps.rx.java
     implementation deps.androidx.v13
-    implementation deps.androidx.collection
     implementation deps.androidx.annotation
     implementation deps.androidx.recyclerview
     implementation deps.androidx.emojiAppCompat

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     implementation deps.guava.android
     implementation deps.rx.android
     implementation deps.rx.java
-    implementation deps.androidx.v13
     implementation deps.androidx.annotation
     implementation deps.androidx.recyclerview
     implementation deps.androidx.emojiAppCompat

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -23,8 +23,8 @@ dependencies {
     implementation deps.rx.android
     implementation deps.rx.java
     implementation deps.androidx.annotation
+    implementation deps.androidx.appcompat
     implementation deps.androidx.recyclerview
-    implementation deps.androidx.emojiAppCompat
 
     implementation deps.kotlin.stdlib
 

--- a/lib/src/main/java/com/snap/ui/recycling/prefetch/InflaterCache.kt
+++ b/lib/src/main/java/com/snap/ui/recycling/prefetch/InflaterCache.kt
@@ -1,8 +1,8 @@
 package com.snap.ui.recycling.prefetch
 
 import android.util.LongSparseArray
+import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
-import androidx.appcompat.view.ContextThemeWrapper
 import java.lang.ref.WeakReference
 
 /**

--- a/lib/src/main/java/com/snap/ui/seeking/SparseUpdateSeekable.kt
+++ b/lib/src/main/java/com/snap/ui/seeking/SparseUpdateSeekable.kt
@@ -1,13 +1,13 @@
 package com.snap.ui.seeking
 
-import androidx.collection.SparseArrayCompat
+import android.util.SparseArray
 
 /**
  * A Seekable built on top of another Seekable, with a sparse layer of overlayed updates.
  */
 class SparseUpdateSeekable<T>(private val source: Seekable<T>) : Seekable<T> {
 
-    private val updates = SparseArrayCompat<T>()
+    private val updates = SparseArray<T>()
 
     override fun size() = source.size()
     override fun iterator() = SeekableIterator(this)

--- a/recycling-example/build.gradle
+++ b/recycling-example/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "com.snap.recyclingexample"
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion 29
         multiDexEnabled true
         versionCode 1


### PR DESCRIPTION
Cleanup dependencies a bit:

  - Set minSdk to 21 (fixes runtime crashes on old versions of Android)
  - Set the targetSdk to 29
  - Remove `androidx.collection`, `androidx.emoji` and `androidx.v13`