### PR TITLE
Make most Seekable implementations internal

### DIFF
--- a/lib/src/main/java/com/snap/ui/seeking/ConcatSeekable.kt
+++ b/lib/src/main/java/com/snap/ui/seeking/ConcatSeekable.kt
@@ -3,7 +3,7 @@ package com.snap.ui.seeking
 /**
  * A Seekable made by concatenating a list of Seekables together.
  */
-class ConcatSeekable<T>(private val list: List<Seekable<T>>) : Seekable<T> {
+internal class ConcatSeekable<T>(private val list: List<Seekable<T>>) : Seekable<T> {
 
     override fun get(position: Int): T {
         var positionInSection = position

--- a/lib/src/main/java/com/snap/ui/seeking/ConcatSeekable.kt
+++ b/lib/src/main/java/com/snap/ui/seeking/ConcatSeekable.kt
@@ -7,8 +7,7 @@ class ConcatSeekable<T>(private val list: List<Seekable<T>>) : Seekable<T> {
 
     override fun get(position: Int): T {
         var positionInSection = position
-        for (i in 0 until list.size) {
-            val section = list[i]
+        for (section in list) {
             val sectionSize = section.size()
             if (positionInSection < sectionSize) {
                 return section[positionInSection]

--- a/lib/src/main/java/com/snap/ui/seeking/CursorSeekable.kt
+++ b/lib/src/main/java/com/snap/ui/seeking/CursorSeekable.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 class CursorSeekable<T>(
     private val cursor: Cursor,
-    internal var mapper: Function<Cursor, T>
+    private var mapper: Function<Cursor, T>
 ) : Seekable<T>, Disposable {
 
     private val disposed = AtomicBoolean(false)

--- a/lib/src/main/java/com/snap/ui/seeking/CursorSeekable.kt
+++ b/lib/src/main/java/com/snap/ui/seeking/CursorSeekable.kt
@@ -22,9 +22,7 @@ class CursorSeekable<T>(
      * of the data set. You may want to ensure the first call to this method or [Cursor.getCount]
      * occurs on a background thread.
      */
-    override fun size(): Int {
-        return cursor.count
-    }
+    override fun size(): Int = cursor.count
 
     override fun get(position: Int): T {
         if (position < 0 || position >= cursor.count) {

--- a/lib/src/main/java/com/snap/ui/seeking/ListSeekable.kt
+++ b/lib/src/main/java/com/snap/ui/seeking/ListSeekable.kt
@@ -4,7 +4,7 @@ package com.snap.ui.seeking
  * Wraps a [java.util.List] as a [Seekable].
  */
 
-data class ListSeekable<T>(private val list: List<T>) : Seekable<T> {
+internal data class ListSeekable<T>(private val list: List<T>) : Seekable<T> {
 
     override fun get(position: Int): T = list[position]
 

--- a/lib/src/main/java/com/snap/ui/seeking/ReversingSeekable.kt
+++ b/lib/src/main/java/com/snap/ui/seeking/ReversingSeekable.kt
@@ -3,7 +3,7 @@ package com.snap.ui.seeking
 /**
  * A Seekable that reverses another Seekable.
  */
-class ReversingSeekable<T>(private val source: Seekable<T>) : Seekable<T> {
+internal class ReversingSeekable<T>(private val source: Seekable<T>) : Seekable<T> {
 
     override fun get(position: Int): T = source[size() - position - 1]
 

--- a/lib/src/main/java/com/snap/ui/seeking/SeekableTransform.kt
+++ b/lib/src/main/java/com/snap/ui/seeking/SeekableTransform.kt
@@ -3,7 +3,7 @@ package com.snap.ui.seeking
 /**
  * A Seekable that maps each item from a given Seekable.
  */
-class SeekableTransform<S, T> internal constructor(
+internal class SeekableTransform<S, T> internal constructor(
     private val source: Seekable<S>,
     private val mapping: (s: S, position: Int) -> T
 ) : Seekable<T> {

--- a/lib/src/main/java/com/snap/ui/seeking/SplicingSeekable.kt
+++ b/lib/src/main/java/com/snap/ui/seeking/SplicingSeekable.kt
@@ -7,7 +7,7 @@ import kotlin.math.min
  * If `spliceAt` is beyond the length of `content`, then `splice`
  * is appended to the end of `content`.
  */
-class SplicingSeekable<T>(
+internal class SplicingSeekable<T>(
     private val content: Seekable<T>,
     private val splice: Seekable<T>,
     private val splicePosition: Int

--- a/lib/src/main/java/com/snap/ui/seeking/SplicingSeekable.kt
+++ b/lib/src/main/java/com/snap/ui/seeking/SplicingSeekable.kt
@@ -1,5 +1,7 @@
 package com.snap.ui.seeking
 
+import kotlin.math.min
+
 /**
  * A [Seekable] that splices another Seekable at the given position.
  * If `spliceAt` is beyond the length of `content`, then `splice`
@@ -7,8 +9,7 @@ package com.snap.ui.seeking
  */
 class SplicingSeekable<T>(
     private val content: Seekable<T>,
-    private
-        val splice: Seekable<T>,
+    private val splice: Seekable<T>,
     private val splicePosition: Int
 ) : Seekable<T> {
 
@@ -20,16 +21,16 @@ class SplicingSeekable<T>(
                 splice[position - content.size()]
             }
         } else {
-            val contentSeen = Math.min(splicePosition, content.size())
-            if (splicePosition < content.size()) {
+            val contentSeen = min(splicePosition, content.size())
+            return if (splicePosition < content.size()) {
                 val offset = position - contentSeen
-                return if (offset < splice.size()) {
+                if (offset < splice.size()) {
                     splice[offset]
                 } else {
                     content[position - splice.size()]
                 }
             } else {
-                return splice[position - content.size()]
+                splice[position - content.size()]
             }
         }
     }

--- a/recycling-example/src/main/java/com/snap/recyclingexample/ui/cats/CatListSection.kt
+++ b/recycling-example/src/main/java/com/snap/recyclingexample/ui/cats/CatListSection.kt
@@ -8,7 +8,6 @@ import com.snap.recyclingexample.ui.cats.view.CatViewModel
 import com.snap.recyclingexample.ui.cats.view.HeaderViewModel
 import com.snap.ui.recycling.ObservableSectionController
 import com.snap.ui.recycling.viewmodel.AdapterViewModel
-import com.snap.ui.seeking.ListSeekable
 import com.snap.ui.seeking.Seekable
 import com.snap.ui.seeking.Seekables
 import io.reactivex.Observable
@@ -42,19 +41,19 @@ class CatListSection(
                             .filter { catFilter(it, pageState) }
                             .map { CatViewModel(it) }
 
-                    val bigModels: Seekable<AdapterViewModel> = if (big.isEmpty()) Seekables.empty() else ListSeekable(
+                    val bigModels: Seekable<AdapterViewModel> = if (big.isEmpty()) Seekables.empty() else Seekables.copyOf(
                             big.toMutableList<AdapterViewModel>().apply {
                                 add(0, HeaderViewModel("Big Cats"))
                             }
                     )
 
-                    val mediumModels: Seekable<AdapterViewModel> = if (medium.isEmpty()) Seekables.empty() else ListSeekable(
+                    val mediumModels: Seekable<AdapterViewModel> = if (medium.isEmpty()) Seekables.empty() else Seekables.copyOf(
                             medium.toMutableList<AdapterViewModel>().apply {
                                 add(0, HeaderViewModel("Medium Cats"))
                             }
                     )
 
-                    val smallModels: Seekable<AdapterViewModel> = if (small.isEmpty()) Seekables.empty() else ListSeekable(
+                    val smallModels: Seekable<AdapterViewModel> = if (small.isEmpty()) Seekables.empty() else Seekables.copyOf(
                             small.toMutableList<AdapterViewModel>().apply {
                                 add(0, HeaderViewModel("Small Cats"))
                             }

--- a/recycling-example/src/main/java/com/snap/recyclingexample/ui/cats/data/CatsDatabase.kt
+++ b/recycling-example/src/main/java/com/snap/recyclingexample/ui/cats/data/CatsDatabase.kt
@@ -12,8 +12,8 @@ import com.snap.recyclingexample.ui.cats.RAGDOLL_URI
 import com.snap.recyclingexample.ui.cats.SIAMESE_URI
 import com.snap.recyclingexample.ui.cats.TABBY_URI
 import com.snap.recyclingexample.ui.cats.TIGER_URI
-import com.snap.ui.seeking.ListSeekable
 import com.snap.ui.seeking.Seekable
+import com.snap.ui.seeking.Seekables
 import io.reactivex.Observable
 import io.reactivex.schedulers.Schedulers
 
@@ -24,7 +24,7 @@ class CatsDatabase {
             // Simulates a stable id
             var catId = 0L
 
-            ListSeekable(listOf(
+            Seekables.copyOf(listOf(
                     CatData(
                             catId++,
                             CatType.Big,


### PR DESCRIPTION
The advocated way to init `Seekable` is the `Seekables` factory. Having 2 different ways to use them feels tedious and unclear for new clients of the library. At the same time, while this works great for most of them, it doesn’t for `CursorSeekable` & `SparseUpdateSeekable` that have additional API…

Happy to discuss this :)