### PR TITLE
Tiny fixes

### DIFF
--- a/lib/src/main/java/com/snap/ui/recycling/adapter/LoopingAdapter.java
+++ b/lib/src/main/java/com/snap/ui/recycling/adapter/LoopingAdapter.java
@@ -191,7 +191,7 @@ public class LoopingAdapter<T extends ViewHolder> extends RecyclerView.Adapter<T
         } else {
             // Scroll to the position with previous scroll offset so user don't see flickering when updating data
             final int scrollOffset =
-                    layoutManager.getOrientation() == LinearLayoutManager.VERTICAL ? scrollOffsetY : scrollOffsetX;
+                    layoutManager.getOrientation() == RecyclerView.VERTICAL ? scrollOffsetY : scrollOffsetX;
             layoutManager.scrollToPositionWithOffset(
                     getLoopingPosition(adapter.getItemCount(), currentPosition),
                     scrollOffset);

--- a/lib/src/main/java/com/snap/ui/recycling/adapter/ObservableViewModelSectionAdapter.kt
+++ b/lib/src/main/java/com/snap/ui/recycling/adapter/ObservableViewModelSectionAdapter.kt
@@ -295,9 +295,12 @@ open class ObservableViewModelSectionAdapter
         override fun getNewListSize() = newModels.size()
 
         override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-            val first = oldModels[oldItemPosition]
-            val second = newModels[newItemPosition]
-            return first.model.areContentsTheSame(second.model)
+            // DiffUtil does not respect the contract of calling
+            // areContentsTheSame only when areItemsTheSame returns true
+            // cf https://issuetracker.google.com/issues/123376278
+            val firstModel = oldModels[oldItemPosition].model
+            val secondModel = newModels[newItemPosition].model
+            return firstModel.areItemsTheSame(secondModel) && firstModel.areContentsTheSame(secondModel)
         }
 
         override fun getChangePayload(oldItemPosition: Int, newItemPosition: Int) = oldModels[oldItemPosition]


### PR DESCRIPTION
DiffUtil can get get confused when an item in the original list is duplicated, by short-circuting the path between the duplicate instances. For instance:

listAdapter.submitList(Arrays.asList("one", null));
listAdapter.submitList(Arrays.asList("one", null, "two", null));

In order to prevent breaking the contract of areContentTheSame being called only when areItemsTheSame, let’s check areItemsTheSame first.

This commit can be reverted once we switch to RecyclerView 1.2.0-alpha02 as DiffUtil was patched (cf https://developer.android.com/jetpack/androidx/releases/recyclerview#recyclerview-1.2.0-alpha02)

Also cf https://android-review.googlesource.com/c/platform/frameworks/support/+/1253271/ for the rewrite of DiffUtil that will patch this once and for all.